### PR TITLE
Use MB instead of Bytes in setting bucket quota

### DIFF
--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -37,7 +37,7 @@ output "minio_url" {
 - **bucket_prefix** (String)
 - **force_destroy** (Boolean)
 - **id** (String) The ID of this resource.
-- **quota** (Number) The limit of the amount of data in the bucket (bytes).
+- **quota** (Number) The limit of the amount of data in the bucket (Mbytes).
 - **object_locking** (Boolean) - Whether object locking should be enabled for the bucket.
 
 ### Read-Only

--- a/minio/resource_minio_s3_bucket.go
+++ b/minio/resource_minio_s3_bucket.go
@@ -69,7 +69,7 @@ func resourceMinioBucket() *schema.Resource {
 				Computed: true,
 			},
 			"quota": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeFloat,
 				Optional: true,
 			},
 			"object_locking": {
@@ -185,7 +185,9 @@ func minioUpdateBucket(ctx context.Context, d *schema.ResourceData, meta interfa
 		log.Printf("[DEBUG] Updating bucket, quota changed. Bucket: [%s], Region: [%s]",
 			bucketConfig.MinioBucket, bucketConfig.MinioRegion)
 
-		bucketQuota := madmin.BucketQuota{Quota: uint64(d.Get("quota").(int)), Type: madmin.HardQuota}
+		quotaInMB := d.Get("quota").(float64)
+		quotaInBytes := uint64(quotaInMB * 1024 * 1024)
+		bucketQuota := madmin.BucketQuota{Quota: quotaInBytes, Type: madmin.HardQuota}
 
 		if err := minioSetBucketQuota(ctx, bucketConfig, &bucketQuota); err != nil {
 			log.Printf("%s", NewResourceErrorStr("unable to update bucket", bucketConfig.MinioBucket, err))


### PR DESCRIPTION
This PR implements the following changes:

 - Use MB instead of Bytes in setting bucket quota