### PR TITLE
Update repository URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Contributions are what make the open source community such an amazing place to b
 2. Create your Feature Branch (`git checkout -b feature/TerraformFeature`)
 3. Commit your Changes (`git commit -m 'Add some TerraformFeature'`)
 4. Push to the Branch (`git push origin feature/TerraformFeature`)
-5. Open a [Pull Request](https://github.com/aminueza/terraform-provider-minio/pulls)
+5. Open a [Pull Request](https://github.com/terraform-provider-minio/terraform-provider-minio/pulls)
 
 ### Merging
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 <p align="center">
-  <a href="https://github.com/aminueza/terraform-provider-minio">
+  <a href="https://github.com/terraform-provider-minio/terraform-provider-minio">
     <img src="https://i.imgur.com/yijdDec.png" alt="minio-provider-terraform" width="200">
   </a>
   <h3 align="center" style="font-weight: bold">Terraform Provider for MinIO</h3>
   <p align="center">
-    <a href="https://github.com/aminueza/terraform-provider-minio/graphs/contributors">
-      <img alt="Contributors" src="https://img.shields.io/github/contributors/aminueza/terraform-provider-minio">
+    <a href="https://github.com/terraform-provider-minio/terraform-provider-minio/graphs/contributors">
+      <img alt="Contributors" src="https://img.shields.io/github/contributors/terraform-provider-minio/terraform-provider-minio">
     </a>
     <a href="https://golang.org/doc/devel/release.html">
-      <img alt="GitHub go.mod Go version" src="https://img.shields.io/github/go-mod/go-version/aminueza/terraform-provider-minio">
+      <img alt="GitHub go.mod Go version" src="https://img.shields.io/github/go-mod/go-version/terraform-provider-minio/terraform-provider-minio">
     </a>
-    <a href="https://github.com/aminueza/terraform-provider-minio/actions?query=workflow%3A%22Terraform+Provider+CI%22">
-      <img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/aminueza/terraform-provider-minio/go.yml?branch=master">
+    <a href="https://github.com/terraform-provider-minio/terraform-provider-minio/actions?query=workflow%3A%22Terraform+Provider+CI%22">
+      <img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/terraform-provider-minio/terraform-provider-minio/go.yml?branch=master">
     </a>
-    <a href="https://github.com/aminueza/terraform-provider-minio/releases">
-      <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/aminueza/terraform-provider-minio?include_prereleases">
+    <a href="https://github.com/terraform-provider-minio/terraform-provider-minio/releases">
+      <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/terraform-provider-minio/terraform-provider-minio?include_prereleases">
     </a>
   </p>
   <p align="center">
-    <a href="https://github.com/aminueza/terraform-provider-minio/tree/master/docs"><strong>Explore the docs »</strong></a>
+    <a href="https://github.com/terraform-provider-minio/terraform-provider-minio/tree/master/docs"><strong>Explore the docs »</strong></a>
   </p>
 </p>
 
@@ -51,7 +51,7 @@ It just means that we can't guarantee backward compatibility.
 
 ## Building and Installing
 
-Prebuilt versions of this provider are available on the [releases page](https://github.com/aminueza/terraform-provider-minio/releases/latest).
+Prebuilt versions of this provider are available on the [releases page](https://github.com/terraform-provider-minio/terraform-provider-minio/releases/latest).
 
 But if you need to build it yourself, just download this repository, [install](https://taskfile.dev/#/installation) [Task](https://taskfile.dev/):
 
@@ -118,7 +118,7 @@ See our [examples](./examples/) folder.
 
 ## Roadmap
 
-See the [open issues](https://github.com/aminueza/terraform-provider-minio/issues) for a list of proposed features (and known issues). See [CONTRIBUTING](./.github/CONTRIBUTING.md) for more information.
+See the [open issues](https://github.com/terraform-provider-minio/terraform-provider-minio/issues) for a list of proposed features (and known issues). See [CONTRIBUTING](./.github/CONTRIBUTING.md) for more information.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aminueza/terraform-provider-minio
+module github.com/terraform-provider-minio/terraform-provider-minio
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 
-	"github.com/aminueza/terraform-provider-minio/minio"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/terraform-provider-minio/terraform-provider-minio/minio"
 )
 
 func main() {


### PR DESCRIPTION
As the repository has been moved to an organization, we should update all URLs to use the organization name.

Note that this PR doesn't change the [Provider name in Terraform registry](https://registry.terraform.io/providers/aminueza/minio).