### PR TITLE
Update goreleaser-action to v5 and add permission for the workflow to attach binaries to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
   push:
     tags:
       - "v*"
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -33,7 +35,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Update goreleaser-action to v5 and add permission for the workflow to attach binaries to GitHub Releases.

Reference: https://github.com/goreleaser/goreleaser-action?tab=readme-ov-file#workflow

Note for the reviewer: The updated workflow [has been tested here](https://github.com/terraform-provider-minio/terraform-provider-minio/actions/runs/6274593669/job/17040285415), and it [successfully released the provider version 1.18.1](https://github.com/terraform-provider-minio/terraform-provider-minio/releases/tag/v1.18.1).