### PR TITLE
Add service account values to read and import

### DIFF
--- a/minio/resource_minio_service_account.go
+++ b/minio/resource_minio_service_account.go
@@ -175,6 +175,12 @@ func minioReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 		return NewResourceError("reading service account failed", d.Id(), err)
 	}
 
+	_ = d.Set("disable_user", output.AccountStatus == "off")
+
+	if err := d.Set("target_user", output.ParentUser); err != nil {
+		return NewResourceError("reading service account failed", d.Id(), err)
+	}
+
 	_ = d.Set("policy", output.Policy)
 
 	return nil

--- a/minio/resource_minio_service_account_test.go
+++ b/minio/resource_minio_service_account_test.go
@@ -30,7 +30,14 @@ func TestServiceAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioServiceAccountExists(resourceName, &serviceAccount),
 					testAccCheckMinioServiceAccountAttributes(resourceName, targetUser, status),
+					resource.TestCheckResourceAttr(resourceName, "target_user", targetUser),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_secret", "secret_key"},
 			},
 		},
 	})
@@ -129,6 +136,12 @@ func TestServiceAccount_Policy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioServiceAccountExists(resourceName2, &serviceAccount),
 				),
+			},
+			{
+				ResourceName:            resourceName2,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_secret", "secret_key"},
 			},
 		},
 	})


### PR DESCRIPTION
# Add service account values to read and import

Adds `disable_user` and `target_user` to `minio_service_account` on import which were previously missing. The more important one is `minio_service_account`, but in case `disable_user` presented issues I added it as well. `disable_user` is not checked for errors since it's pulled from the account status which is already checked.

I didn't include `secret_key` because it's computed and unless I'm misunderstanding the implementation wouldn't be necessary here.

I may have missed things in the implementation, happy to make changes!

## Closing issues

- Closes: #481
