### PR TITLE
Add Noncurrent Version expiration to ilm policy

### DIFF
--- a/docs/resources/ilm_policy.md
+++ b/docs/resources/ilm_policy.md
@@ -46,6 +46,7 @@ Optional:
 
 - `expiration` (String)
 - `filter` (String)
+- `noncurrentversionexpiration` (String)
 - `tags` (Map of String)
 
 Read-Only:

--- a/docs/resources/ilm_policy.md
+++ b/docs/resources/ilm_policy.md
@@ -46,7 +46,7 @@ Optional:
 
 - `expiration` (String)
 - `filter` (String)
-- `noncurrentversionexpiration` (String)
+- `noncurrent_version_expiration_days` (Int)
 - `tags` (Map of String)
 
 Read-Only:

--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -101,9 +101,7 @@ func minioCreateILMPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 
 		var filter lifecycle.Filter
 
-        var noncurrentVersionExpirationDays lifecycle.NoncurrentVersionExpiration
-
-        noncurrentVersionExpirationDays = lifecycle.NoncurrentVersionExpiration{NoncurrentDays: lifecycle.ExpirationDays(rule["noncurrent_version_expiration_days"].(int))}
+        noncurrentVersionExpirationDays := lifecycle.NoncurrentVersionExpiration{NoncurrentDays: lifecycle.ExpirationDays(rule["noncurrent_version_expiration_days"].(int))}
 
 		tags := map[string]string{}
 		for k, v := range rule["tags"].(map[string]interface{}) {

--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -101,7 +101,7 @@ func minioCreateILMPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 
 		var filter lifecycle.Filter
 
-        noncurrentVersionExpirationDays := lifecycle.NoncurrentVersionExpiration{NoncurrentDays: lifecycle.ExpirationDays(rule["noncurrent_version_expiration_days"].(int))}
+		noncurrentVersionExpirationDays := lifecycle.NoncurrentVersionExpiration{NoncurrentDays: lifecycle.ExpirationDays(rule["noncurrent_version_expiration_days"].(int))}
 
 		tags := map[string]string{}
 		for k, v := range rule["tags"].(map[string]interface{}) {
@@ -179,12 +179,12 @@ func minioReadILMPolicy(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 
 		rule := map[string]interface{}{
-			"id":                          r.ID,
-			"expiration":                  expiration,
+			"id":                                 r.ID,
+			"expiration":                         expiration,
 			"noncurrent_version_expiration_days": noncurrentVersionExpirationDays,
-			"status":                      r.Status,
-			"filter":                      prefix,
-			"tags":                        tags,
+			"status":                             r.Status,
+			"filter":                             prefix,
+			"tags":                               tags,
 		}
 		rules = append(rules, rule)
 	}

--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -117,11 +117,11 @@ func minioCreateILMPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		r := lifecycle.Rule{
-			ID:         rule["id"].(string),
-			Expiration: parseILMExpiration(rule["expiration"].(string)),
+			ID:                          rule["id"].(string),
+			Expiration:                  parseILMExpiration(rule["expiration"].(string)),
 			NoncurrentVersionExpiration: parseILMNoncurrentVersionExpiration(rule["noncurrentversionexpiration"].(string)),
-			Status:     "Enabled",
-			RuleFilter: filter,
+			Status:                      "Enabled",
+			RuleFilter:                  filter,
 		}
 		config.Rules = append(config.Rules, r)
 	}
@@ -178,12 +178,12 @@ func minioReadILMPolicy(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 
 		rule := map[string]interface{}{
-			"id":         r.ID,
-			"expiration": expiration,
+			"id":                          r.ID,
+			"expiration":                  expiration,
 			"noncurrentversionexpiration": noncurrentversionexpiration,
-			"status":     r.Status,
-			"filter":     prefix,
-			"tags":       tags,
+			"status":                      r.Status,
+			"filter":                      prefix,
+			"tags":                        tags,
 		}
 		rules = append(rules, rule)
 	}

--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -44,7 +44,7 @@ func resourceMinioILMPolicy() *schema.Resource {
 							Optional:         true,
 							ValidateDiagFunc: validateILMExpiration,
 						},
-						"noncurrentversionexpiration": {
+						"noncurrent_version_expiration_days": {
 							Type:             schema.TypeString,
 							Optional:         true,
 							ValidateDiagFunc: validateILMNoncurrentVersionExpiration,
@@ -84,7 +84,7 @@ func validateILMNoncurrentVersionExpiration(v interface{}, p cty.Path) (errors d
 	exp := parseILMNoncurrentVersionExpiration(value)
 
 	if (lifecycle.NoncurrentVersionExpiration{}) == exp {
-		return diag.Errorf("noncurrentversionexpiration must be a duration (5d)")
+		return diag.Errorf("noncurrent_version_expiration_days must be a duration (5d)")
 	}
 
 	return
@@ -119,7 +119,7 @@ func minioCreateILMPolicy(ctx context.Context, d *schema.ResourceData, meta inte
 		r := lifecycle.Rule{
 			ID:                          rule["id"].(string),
 			Expiration:                  parseILMExpiration(rule["expiration"].(string)),
-			NoncurrentVersionExpiration: parseILMNoncurrentVersionExpiration(rule["noncurrentversionexpiration"].(string)),
+			NoncurrentVersionExpiration: parseILMNoncurrentVersionExpiration(rule["noncurrent_version_expiration_days"].(string)),
 			Status:                      "Enabled",
 			RuleFilter:                  filter,
 		}
@@ -161,9 +161,9 @@ func minioReadILMPolicy(ctx context.Context, d *schema.ResourceData, meta interf
 			expiration = r.Expiration.Date.Format("2006-01-02")
 		}
 
-		var noncurrentversionexpiration string
+		var noncurrentVersionExpirationDays string
 		if r.NoncurrentVersionExpiration.NoncurrentDays != 0 {
-			noncurrentversionexpiration = fmt.Sprintf("%dd", r.NoncurrentVersionExpiration.NoncurrentDays)
+			noncurrentVersionExpirationDays = fmt.Sprintf("%dd", r.NoncurrentVersionExpiration.NoncurrentDays)
 		}
 
 		var prefix string
@@ -180,7 +180,7 @@ func minioReadILMPolicy(ctx context.Context, d *schema.ResourceData, meta interf
 		rule := map[string]interface{}{
 			"id":                          r.ID,
 			"expiration":                  expiration,
-			"noncurrentversionexpiration": noncurrentversionexpiration,
+			"noncurrent_version_expiration_days": noncurrentVersionExpirationDays,
 			"status":                      r.Status,
 			"filter":                      prefix,
 			"tags":                        tags,

--- a/minio/resource_minio_ilm_policy.go
+++ b/minio/resource_minio_ilm_policy.go
@@ -232,12 +232,3 @@ func parseILMExpiration(s string) lifecycle.Expiration {
 
 	return lifecycle.Expiration{}
 }
-
-func parseILMNoncurrentVersionExpiration(s string) lifecycle.NoncurrentVersionExpiration {
-	var days int
-	if _, err := fmt.Sscanf(s, "%dd", &days); err == nil {
-		return lifecycle.NoncurrentVersionExpiration{NoncurrentDays: lifecycle.ExpirationDays(days)}
-	}
-
-	return lifecycle.NoncurrentVersionExpiration{}
-}

--- a/minio/resource_minio_ilm_policy_test.go
+++ b/minio/resource_minio_ilm_policy_test.go
@@ -105,6 +105,8 @@ func TestAccILMPolicy_expireNoncurrentVersion(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMinioILMPolicyExists(resourceName, &lifecycleConfig),
 					testAccCheckMinioLifecycleConfigurationValid(&lifecycleConfig),
+					resource.TestCheckResourceAttr(
+						resourceName, "rule.0.noncurrent_version_expiration_days", "5"),
 				),
 			},
 		},

--- a/minio/resource_minio_ilm_policy_test.go
+++ b/minio/resource_minio_ilm_policy_test.go
@@ -241,7 +241,7 @@ resource "minio_ilm_policy" "rule4" {
   rule {
 	id = "expireNoncurrentVersion"
 	expiration = "5d"
-	noncurrent_version_expiration_days = "5d"
+	noncurrent_version_expiration_days = 5
   }
 }
 `, randInt)

--- a/minio/resource_minio_ilm_policy_test.go
+++ b/minio/resource_minio_ilm_policy_test.go
@@ -241,7 +241,7 @@ resource "minio_ilm_policy" "rule4" {
   rule {
 	id = "expireNoncurrentVersion"
 	expiration = "5d"
-	noncurrentversionexpiration = "5d"
+	noncurrent_version_expiration_days = "5d"
   }
 }
 `, randInt)


### PR DESCRIPTION
## Add Noncurrent Version expiration to ilm policy

This PR implements the following changes:

Adds noncurrentversionexpiration to minio_ilm_policy to support this option:
[Minio-go](https://github.com/minio/minio-go/blob/master/pkg/lifecycle/lifecycle.go#L50
)

New parameters will look like this:

```
resource "minio_ilm_policy" "bucket-lifecycle-rules" {
  bucket = minio_s3_bucket.bucket.bucket

  rule {
    id = "expire-noncurrentversion-7d"
    noncurrent_version_expiration_days = "7"
  }
}
```

Actually expired objects on versioned buckets are never deleted

## Closing issues

- Closes: #523 
